### PR TITLE
Feat: add `unassign` command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -260,6 +260,19 @@ Examples:
 - `assign c/1 t/1` Assigns the task at index 1 to the contact at index 1.
 - `assign c/3 t/2` Assigns the task at index 2 to the contact at index 3.
 
+### Unassigning tasks to contacts: `unassign`
+
+Unassigns a task to a contact shown in the task list and contact list respectively.
+
+Format: `unassign c/CONTACT_INDEX t/TASK_INDEX`
+
+- Unassigns the task at the specified `TASK_INDEX` to the contact at the specified `CONTACT_INDEX`. The indices refer to the index number shown in the displayed task list and contact list respectively. The indices **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+
+- `unassign c/1 t/1` Unassigns the task at index 1 to the contact at index 1.
+- `unassign c/3 t/2` Unassigns the task at index 2 to the contact at index 3.
+
 ### Exiting the program : `exit`
 
 Exits the program.

--- a/src/main/java/swift/logic/commands/CommandSuggestor.java
+++ b/src/main/java/swift/logic/commands/CommandSuggestor.java
@@ -70,6 +70,9 @@ public class CommandSuggestor {
 
         commandList.add(AssignCommand.COMMAND_WORD);
         argPrefixList.add(AssignCommand.ARGUMENT_PREFIXES);
+
+        commandList.add(UnassignCommand.COMMAND_WORD);
+        argPrefixList.add(UnassignCommand.ARGUMENT_PREFIXES);
     }
 
     /**

--- a/src/main/java/swift/logic/commands/CommandType.java
+++ b/src/main/java/swift/logic/commands/CommandType.java
@@ -11,5 +11,6 @@ public enum CommandType {
     CLEAR,
     SELECT_TASK,
     SELECT_CONTACT,
-    ASSIGN
+    ASSIGN,
+    UNASSIGN
 }

--- a/src/main/java/swift/logic/commands/UnassignCommand.java
+++ b/src/main/java/swift/logic/commands/UnassignCommand.java
@@ -27,7 +27,8 @@ public class UnassignCommand extends Command {
             List.of(PREFIX_CONTACT, PREFIX_TASK));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Unassigns the task to the contact identified by the index numbers used in the displayed contact list.\n"
+            + ": Unassigns the task to the contact identified by the index numbers used in the "
+            + "displayed contact list.\n"
             + "Parameters: "
             + PREFIX_CONTACT + "CONTACT_INDEX "
             + PREFIX_TASK + "TASK_INDEX\n"

--- a/src/main/java/swift/logic/commands/UnassignCommand.java
+++ b/src/main/java/swift/logic/commands/UnassignCommand.java
@@ -1,0 +1,93 @@
+package swift.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static swift.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static swift.logic.parser.CliSyntax.PREFIX_TASK;
+import static swift.model.Model.PREDICATE_SHOW_ALL_BRIDGE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import swift.commons.core.Messages;
+import swift.commons.core.index.Index;
+import swift.logic.commands.exceptions.CommandException;
+import swift.logic.parser.Prefix;
+import swift.model.Model;
+import swift.model.bridge.PersonTaskBridge;
+import swift.model.person.Person;
+import swift.model.task.Task;
+
+/**
+ * Unassigns a task to a contact identified using their displayed index from the
+ * address book.
+ */
+public class UnassignCommand extends Command {
+    public static final String COMMAND_WORD = "unassign";
+    public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(
+            List.of(PREFIX_CONTACT, PREFIX_TASK));
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unassigns the task to the contact identified by the index numbers used in the displayed contact list.\n"
+            + "Parameters: "
+            + PREFIX_CONTACT + "CONTACT_INDEX "
+            + PREFIX_TASK + "TASK_INDEX\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_CONTACT + "1 "
+            + PREFIX_TASK + "2";
+
+    public static final String MESSAGE_UNASSIGN_SUCCESS = "Task %1$s unassigned to contact %2$s!";
+    public static final String MESSAGE_BRIDGE_DOESNT_EXIST = "This task is not assigned to this contact!";
+
+    private final Index contactIndex;
+    private final Index taskIndex;
+
+    /**
+     * Creates an UnassignCommand to add the specified {@code Task} to the specified
+     * {@code Person}
+     *
+     * @param contactIndex Index of the contact to assign the task to.
+     * @param taskIndex    Index of the task to be assigned.
+     */
+    public UnassignCommand(Index contactIndex, Index taskIndex) {
+        this.contactIndex = contactIndex;
+        this.taskIndex = taskIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+        List<Task> lastShownTaskList = model.getFilteredTaskList();
+
+        if (contactIndex.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        if (taskIndex.getZeroBased() >= lastShownTaskList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Person selectedPerson = lastShownPersonList.get(contactIndex.getZeroBased());
+        Task selectedTask = lastShownTaskList.get(taskIndex.getZeroBased());
+        PersonTaskBridge bridge = new PersonTaskBridge(selectedPerson.getId(), selectedTask.getId());
+
+        if (!model.hasBridge(bridge)) {
+            throw new CommandException(MESSAGE_BRIDGE_DOESNT_EXIST);
+        }
+        model.deleteBridge(bridge);
+
+        model.updateFilteredBridgeList(PREDICATE_SHOW_ALL_BRIDGE);
+        model.updateFilteredBridgeList(filteredBridge -> model.getFilteredPersonList().stream()
+                .anyMatch(person -> person.getId().equals(filteredBridge.getPersonId())));
+
+        return new CommandResult(String.format(MESSAGE_UNASSIGN_SUCCESS, selectedTask, selectedPerson),
+                CommandType.UNASSIGN);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnassignCommand // instanceof handles nulls
+                && contactIndex.equals(((UnassignCommand) other).contactIndex)
+                && taskIndex.equals(((UnassignCommand) other).taskIndex)); // state check
+    }
+}

--- a/src/main/java/swift/logic/parser/AddressBookParser.java
+++ b/src/main/java/swift/logic/parser/AddressBookParser.java
@@ -23,6 +23,7 @@ import swift.logic.commands.ListContactCommand;
 import swift.logic.commands.ListTaskCommand;
 import swift.logic.commands.SelectContactCommand;
 import swift.logic.commands.SelectTaskCommand;
+import swift.logic.commands.UnassignCommand;
 import swift.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,8 @@ public class AddressBookParser {
             return new SelectTaskCommandParser().parse(arguments);
         case AssignCommand.COMMAND_WORD:
             return new AssignCommandParser().parse(arguments);
+        case UnassignCommand.COMMAND_WORD:
+            return new UnassignCommandParser().parse(arguments);
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
         case HelpCommand.COMMAND_WORD:

--- a/src/main/java/swift/logic/parser/UnassignCommandParser.java
+++ b/src/main/java/swift/logic/parser/UnassignCommandParser.java
@@ -1,0 +1,55 @@
+package swift.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static swift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static swift.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static swift.logic.parser.CliSyntax.PREFIX_TASK;
+
+import java.util.stream.Stream;
+
+import swift.commons.core.index.Index;
+import swift.logic.commands.UnassignCommand;
+import swift.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AssignCommand object
+ */
+public class UnassignCommandParser implements Parser<UnassignCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the
+     * AssignCommand
+     * and returns a AssignCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnassignCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        System.out.println(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_CONTACT, PREFIX_TASK);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_CONTACT, PREFIX_TASK) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            Index contactIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CONTACT).get());
+            Index taskIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_TASK).get());
+
+            return new UnassignCommand(contactIndex, taskIndex);
+        } catch (Exception e) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE), e);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/swift/model/AddressBook.java
+++ b/src/main/java/swift/model/AddressBook.java
@@ -175,6 +175,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         bridges.add(b);
     }
 
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeBridge(PersonTaskBridge key) {
+        bridges.remove(key);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/swift/model/Model.java
+++ b/src/main/java/swift/model/Model.java
@@ -164,6 +164,13 @@ public interface Model {
      */
     void addBridge(PersonTaskBridge bridge);
 
+    /**
+     * Deletes a relationship between a given task and person.
+     *
+     * @param bridge The bridge to be deleted.
+     */
+    void deleteBridge(PersonTaskBridge bridge);
+
     /** Returns an unmodifiable view of the unfiltered bridge list */
     ObservableList<PersonTaskBridge> getUnfilteredBridgeList();
 

--- a/src/main/java/swift/model/ModelManager.java
+++ b/src/main/java/swift/model/ModelManager.java
@@ -164,6 +164,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteBridge(PersonTaskBridge target) {
+        addressBook.removeBridge(target);
+    }
+
+    @Override
     public void hotUpdateAssociatedContacts() throws CommandException {
         List<Person> currentPersonList = this.getFilteredPersonList();
         boolean isSelected = currentPersonList.size() == 1;

--- a/src/main/java/swift/ui/MainWindow.java
+++ b/src/main/java/swift/ui/MainWindow.java
@@ -292,6 +292,7 @@ public class MainWindow extends UiPart<Stage> {
                 isContactTabShown = false;
                 break;
             case ASSIGN:
+            case UNASSIGN:
                 refreshTab();
                 break;
             case SELECT_CONTACT:

--- a/src/test/java/swift/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/swift/logic/commands/AddContactCommandTest.java
@@ -202,6 +202,11 @@ public class AddContactCommandTest {
         }
 
         @Override
+        public void deleteBridge(PersonTaskBridge target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void hotUpdateAssociatedContacts() {
         }
 

--- a/src/test/java/swift/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/swift/logic/commands/AddTaskCommandTest.java
@@ -211,6 +211,11 @@ public class AddTaskCommandTest {
         }
 
         @Override
+        public void deleteBridge(PersonTaskBridge bridge) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void hotUpdateAssociatedContacts() {
         }
 

--- a/src/test/java/swift/logic/commands/UnassignCommandTest.java
+++ b/src/test/java/swift/logic/commands/UnassignCommandTest.java
@@ -1,0 +1,90 @@
+package swift.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static swift.logic.commands.CommandTestUtil.assertCommandFailure;
+import static swift.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static swift.testutil.TypicalIntegratedAddressBook.getTypicalAddressBook;
+import static swift.testutil.TypicalPersonIndexes.INDEX_FIRST_PERSON;
+import static swift.testutil.TypicalPersonIndexes.INDEX_SECOND_PERSON;
+import static swift.testutil.TypicalTaskIndexes.*;
+
+import org.junit.jupiter.api.Test;
+
+import swift.commons.core.Messages;
+import swift.commons.core.index.Index;
+import swift.model.Model;
+import swift.model.ModelManager;
+import swift.model.UserPrefs;
+import swift.model.bridge.PersonTaskBridge;
+import swift.model.person.Person;
+import swift.model.task.Task;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnassignCommand}.
+ */
+public class UnassignCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
+        Person expectedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Task expectedTask = model.getFilteredTaskList().get(INDEX_FIRST_TASK.getZeroBased());
+        String expectedMessage = String.format(UnassignCommand.MESSAGE_UNASSIGN_SUCCESS, expectedTask, expectedPerson);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        PersonTaskBridge target = new PersonTaskBridge(expectedPerson.getId(), expectedTask.getId());
+        expectedModel.deleteBridge(target);
+
+        assertCommandSuccess(unassignCommand, model, expectedMessage, CommandType.UNASSIGN, expectedModel);
+    }
+
+    @Test
+    public void execute_bridgeDoesNotExist_throwsCommandException() {
+        UnassignCommand unassign = new UnassignCommand(INDEX_FIRST_PERSON, INDEX_THIRD_TASK);
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        assertCommandFailure(unassign, expectedModel, UnassignCommand.MESSAGE_BRIDGE_DOESNT_EXIST);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnassignCommand unassignCommand = new UnassignCommand(outOfBoundIndex, INDEX_FIRST_TASK);
+
+        assertCommandFailure(unassignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidTaskIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        UnassignCommand unassignCommand = new UnassignCommand(INDEX_FIRST_PERSON, outOfBoundIndex);
+
+        assertCommandFailure(unassignCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        UnassignCommand unassignCommand1 = new UnassignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
+        UnassignCommand unassignCommand2 = new UnassignCommand(INDEX_SECOND_PERSON, INDEX_SECOND_TASK);
+
+        // same object -> returns true
+        assertTrue(unassignCommand1.equals(unassignCommand1));
+
+        // same values -> returns true
+        UnassignCommand assignCommand3 = new UnassignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
+        assertTrue(unassignCommand1.equals(assignCommand3));
+
+        // different types -> returns false
+        assertFalse(unassignCommand1.equals(1));
+
+        // null -> returns false
+        assertFalse(unassignCommand1.equals(null));
+
+        // different task -> returns false
+        assertFalse(unassignCommand1.equals(unassignCommand2));
+    }
+}

--- a/src/test/java/swift/logic/commands/UnassignCommandTest.java
+++ b/src/test/java/swift/logic/commands/UnassignCommandTest.java
@@ -7,7 +7,9 @@ import static swift.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static swift.testutil.TypicalIntegratedAddressBook.getTypicalAddressBook;
 import static swift.testutil.TypicalPersonIndexes.INDEX_FIRST_PERSON;
 import static swift.testutil.TypicalPersonIndexes.INDEX_SECOND_PERSON;
-import static swift.testutil.TypicalTaskIndexes.*;
+import static swift.testutil.TypicalTaskIndexes.INDEX_FIRST_TASK;
+import static swift.testutil.TypicalTaskIndexes.INDEX_SECOND_TASK;
+import static swift.testutil.TypicalTaskIndexes.INDEX_THIRD_TASK;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/swift/logic/parser/UnassignCommandParserTest.java
+++ b/src/test/java/swift/logic/parser/UnassignCommandParserTest.java
@@ -1,0 +1,30 @@
+package swift.logic.parser;
+
+import static swift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static swift.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static swift.logic.parser.CliSyntax.PREFIX_TASK;
+import static swift.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static swift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static swift.testutil.TypicalPersonIndexes.INDEX_FIRST_PERSON;
+import static swift.testutil.TypicalTaskIndexes.INDEX_FIRST_TASK;
+
+import org.junit.jupiter.api.Test;
+
+import swift.logic.commands.UnassignCommand;
+
+public class UnassignCommandParserTest {
+
+    private UnassignCommandParser parser = new UnassignCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAssignCommand() {
+        assertParseSuccess(parser, " " + PREFIX_CONTACT + "1 " + PREFIX_TASK + "1",
+                new UnassignCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
## Issues
- Resolves #106 
- Resolves #110 

## Testing
- run the app
- type: `unassign c/1 t/1` -> this should successfully unassign a task
- type: `unassign c/1 t/1` again -> this should throw an error