### PR TITLE
Autocomplete enhancements

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -330,6 +330,8 @@ Swift+ prompts the user with command suggestions as they type, which includes th
 Note:
 - Command Suggestion will not be shown if current user input is invalid and the command text will turn red to alert the users.
 - Autocomplete does not guarantee a successful/valid command unless the given syntax is followed.
+- Autocomplete only completes up to the longest matching prefix if multiple commands are possible with the current user input.
+- However, command suggestions always shows only one of the possible commands.
 
 ---
 

--- a/src/main/java/swift/logic/commands/CommandSuggestor.java
+++ b/src/main/java/swift/logic/commands/CommandSuggestor.java
@@ -4,6 +4,7 @@ import static swift.logic.parser.CliSyntax.PREFIX_KEYWORD;
 
 import java.util.ArrayList;
 import java.util.Collections;
+
 import swift.logic.commands.exceptions.CommandException;
 import swift.logic.parser.ArgumentMultimap;
 import swift.logic.parser.ArgumentTokenizer;
@@ -129,9 +130,8 @@ public class CommandSuggestor {
         String suggestedCommand = commandSuggestion.substring(userInput.length());
         boolean isCommandComplete = userInput.contains(" ");
         int autocompleteUptoIndex;
-        if(isCommandComplete) {
+        if (isCommandComplete) {
             autocompleteUptoIndex = suggestedCommand.indexOf(isCommandComplete ? "/" : " ") + 1;
-
         } else {
             return getLongestMatchingPrefixSuggestion(userInput);
         }
@@ -200,7 +200,6 @@ public class CommandSuggestor {
         return argumentSuggestion;
     }
 
-    
     /**
      * Gets the longest matching prefix from all possible command suggestions depending on the user
      * input.
@@ -229,7 +228,7 @@ public class CommandSuggestor {
 
     /**
      * Gets longest matching prefix from list of strings.
-     * 
+     *
      * @param matchingCommands List of strings.
      * @return Longest matching prefix.
      */

--- a/src/main/java/swift/logic/commands/CommandSuggestor.java
+++ b/src/main/java/swift/logic/commands/CommandSuggestor.java
@@ -3,7 +3,7 @@ package swift.logic.commands;
 import static swift.logic.parser.CliSyntax.PREFIX_KEYWORD;
 
 import java.util.ArrayList;
-
+import java.util.Collections;
 import swift.logic.commands.exceptions.CommandException;
 import swift.logic.parser.ArgumentMultimap;
 import swift.logic.parser.ArgumentTokenizer;
@@ -128,7 +128,13 @@ public class CommandSuggestor {
         // Command suggested but not yet entered by user
         String suggestedCommand = commandSuggestion.substring(userInput.length());
         boolean isCommandComplete = userInput.contains(" ");
-        int autocompleteUptoIndex = suggestedCommand.indexOf(isCommandComplete ? "/" : " ") + 1;
+        int autocompleteUptoIndex;
+        if(isCommandComplete) {
+            autocompleteUptoIndex = suggestedCommand.indexOf(isCommandComplete ? "/" : " ") + 1;
+
+        } else {
+            return getLongestMatchingPrefixSuggestion(userInput);
+        }
 
         // If command has no prefix arguments
         if (autocompleteUptoIndex == 0) {
@@ -192,5 +198,64 @@ public class CommandSuggestor {
             }
         }
         return argumentSuggestion;
+    }
+
+    
+    /**
+     * Gets the longest matching prefix from all possible command suggestions depending on the user
+     * input.
+     *
+     * @param userInput User input.
+     * @return Longest matching prefix.
+     * @throws CommandException If the user input is invalid.
+     */
+    public String getLongestMatchingPrefixSuggestion(String userInput) {
+        assert userInput != null && !userInput.isEmpty();
+        String[] userInputArray = userInput.split(" ", 2);
+        String commandWord = userInputArray[0];
+        boolean isCommandComplete = userInput.contains(" ");
+        ArrayList<String> matchingCommands = new ArrayList<>();
+
+        for (String command : commandList) {
+            if (command.startsWith(commandWord)) {
+                if (isCommandComplete && !command.equals(commandWord)) {
+                    continue;
+                }
+                matchingCommands.add(command + " ");
+            }
+        }
+        return getLongestMatchingPrefix(matchingCommands);
+    }
+
+    /**
+     * Gets longest matching prefix from list of strings.
+     * 
+     * @param matchingCommands List of strings.
+     * @return Longest matching prefix.
+     */
+    public String getLongestMatchingPrefix(ArrayList<String> matchingCommands) {
+        Collections.sort(matchingCommands);
+        int size = matchingCommands.size();
+        if (size == 0) {
+            return "";
+        }
+
+        if (size == 1) {
+            return matchingCommands.get(0);
+        }
+
+        // find the minimum length from first and last string
+        int end =
+                Math.min(matchingCommands.get(0).length(), matchingCommands.get(size - 1).length());
+
+        // find the common prefix between the first and last string
+        int i = 0;
+        while (i < end
+                && matchingCommands.get(0).charAt(i) == matchingCommands.get(size - 1).charAt(i)) {
+            i++;
+        }
+
+        String prefix = matchingCommands.get(0).substring(0, i);
+        return prefix;
     }
 }

--- a/src/test/java/swift/logic/commands/CommandSuggestorTest.java
+++ b/src/test/java/swift/logic/commands/CommandSuggestorTest.java
@@ -125,7 +125,7 @@ public class CommandSuggestorTest {
 
     @Test
     public void autocomplete_validCommandWithNoArgs_success() {
-        String expectedSuggestion = ListTaskCommand.COMMAND_WORD;
+        String expectedSuggestion = ListTaskCommand.COMMAND_WORD + " ";
         try {
             assertEquals(expectedSuggestion, commandSuggestor.autocompleteCommand("list_t",
                     commandSuggestor.suggestCommand("list_t")));


### PR DESCRIPTION
- Use longest matching prefix when autocompleting commands when multiple commands are possible
- Previous implementation always autocompletes with respect to the shown suggestion