### PR TITLE
:bug: Fix: task equality

### DIFF
--- a/src/main/java/swift/model/task/Task.java
+++ b/src/main/java/swift/model/task/Task.java
@@ -103,8 +103,7 @@ public class Task implements Comparable<Task> {
             Task otherTask = (Task) other;
             return name.equals(otherTask.name)
                     && description.equals(otherTask.description)
-                    && deadline.equals(otherTask.deadline)
-                    && isDone == otherTask.isDone;
+                    && deadline.equals(otherTask.deadline);
         }
         return false;
     }


### PR DESCRIPTION
## Description
- Previously there was error with the equality of tasks
  - Tasks use to take into account whether its done or not as part of it's equality check
- This allows mistakes like this to occur:
```
add_task n/abc
add_task n/abc // rightfully shows equality validation error
mark 1
add_task n/abc // allows the task to be added
```
## Issues
- Resolves #167 
- Resolves #169 
- Resolves #171

## Testing
```
add_task n/abc
add_task n/abc // rightfully shows equality validation error
mark 1
add_task n/abc // rightfully shows equality validation error
```
