### PR TITLE
Fix: early truncation of task name bug

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minWidth="1200.0" onCloseRequest="#handleExit" title="Swift+" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minWidth="1200.0" onCloseRequest="#handleExit" title="Swift+" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/swift.png" />
   </icons>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane prefWidth="750.0" HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -8,102 +8,97 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane prefWidth="750.0" HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="-Infinity" minWidth="650.0" prefHeight="90.0" prefWidth="750.0" GridPane.columnIndex="0">
-            <padding>
-                <Insets bottom="5" left="15" right="5" top="5" />
-            </padding>
-            <HBox alignment="CENTER_LEFT" prefHeight="18.0" spacing="5">
-            <StackPane minWidth="-Infinity" prefHeight="150.0" prefWidth="25.0" styleClass="check_icon">
-               <children>
-                  <Label fx:id="checkBox" prefWidth="0.0" styleClass="check_icon">
-                      <graphic>
-                          <ImageView fitHeight="14.0" pickOnBounds="true" preserveRatio="true">
-                              <image>
-                                  <Image url="@/images/check_icon.png" />
-                              </image>
-                          </ImageView>
-                      </graphic>
-                  </Label>
-                  <Label fx:id="uncheckBox" layoutX="24.0" layoutY="14.0" prefWidth="0.0" styleClass="check_icon">
-                      <graphic>
-                          <ImageView fitHeight="14.0" pickOnBounds="true" preserveRatio="true">
-                              <image>
-                                  <Image url="@/images/uncheck_icon.png" />
-                              </image>
-                          </ImageView>
-                      </graphic>
-                  </Label>
-               </children>
-            </StackPane>
-                <Label fx:id="id" styleClass="cell_big_label">
-                    <minWidth>
-                        <!-- Ensures that the label text is never truncated -->
-                        <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                </Label>
-                <Label fx:id="taskName" styleClass="cell_big_label" text="\$first" wrapText="true">
-                    <padding>
-                        <Insets bottom="2.0" right="10.0" top="2.0" />
-                    </padding>
-                </Label>
-                 <FlowPane fx:id="contacts" alignment="CENTER_RIGHT" columnHalignment="RIGHT" prefHeight="18.0" HBox.hgrow="ALWAYS">
-                     <padding>
-                         <Insets right="10.0" />
-                     </padding>
+      <HBox prefHeight="100.0">
+         <children>
+              <VBox alignment="CENTER_LEFT" minHeight="-Infinity" minWidth="650.0">
+                  <padding>
+                      <Insets bottom="5" left="15" right="5" top="5" />
+                  </padding>
+                  <HBox alignment="CENTER_LEFT" spacing="5.0">
+                  <StackPane minWidth="-Infinity" prefWidth="25.0" styleClass="check_icon">
+                     <children>
+                        <Label fx:id="checkBox" styleClass="check_icon">
+                            <graphic>
+                                <ImageView fitHeight="14.0" pickOnBounds="true" preserveRatio="true">
+                                    <image>
+                                        <Image url="@/images/check_icon.png" />
+                                    </image>
+                                </ImageView>
+                            </graphic>
+                        </Label>
+                        <Label fx:id="uncheckBox" layoutX="24.0" layoutY="14.0" styleClass="check_icon">
+                            <graphic>
+                                <ImageView fitHeight="14.0" pickOnBounds="true" preserveRatio="true">
+                                    <image>
+                                        <Image url="@/images/uncheck_icon.png" />
+                                    </image>
+                                </ImageView>
+                            </graphic>
+                        </Label>
+                     </children>
+                  </StackPane>
+                      <Label fx:id="id" minWidth="-Infinity" styleClass="cell_big_label" />
+                      <Label fx:id="taskName" styleClass="cell_big_label" text="\$first" wrapText="true">
+                          <padding>
+                              <Insets bottom="2.0" right="10.0" top="2.0" />
+                          </padding>
+                      </Label>
+                  <VBox.margin>
+                     <Insets />
+                  </VBox.margin>
+                  </HBox>
+                  <HBox alignment="CENTER_LEFT" prefHeight="18.0" translateX="25.0">
+                      <Label styleClass="due_date_label">
+                          <graphic>
+                              <ImageView fitHeight="8.0" pickOnBounds="true" preserveRatio="true">
+                                  <image>
+                                      <Image url="@/images/deadline_icon_2.png" />
+                                  </image>
+                              </ImageView>
+                          </graphic>
+                          <padding>
+                              <Insets bottom="1.0" left="28.0" right="4.0" />
+                          </padding>
+                      </Label>
+                        <Label fx:id="deadline" alignment="TOP_RIGHT" contentDisplay="RIGHT" styleClass="due_date_label" textAlignment="RIGHT">
+                            <padding>
+                                <Insets right="10.0" />
+                            </padding>
+                        </Label>
+                      <Label styleClass="cell_small_label">
+                          <graphic>
+                              <ImageView fitHeight="10.0" pickOnBounds="true" preserveRatio="true">
+                                  <image>
+                                      <Image url="@/images/description_icon_2.png" />
+                                  </image>
+                              </ImageView>
+                          </graphic>
+                          <padding>
+                              <Insets right="4.0" />
+                          </padding>
+                      </Label>
+                      <Label fx:id="description" styleClass="cell_small_label" text="\$description" wrapText="true" />
+                  <VBox.margin>
+                     <Insets bottom="5.0" />
+                  </VBox.margin>
+                  </HBox>
+              </VBox>
+                 <FlowPane fx:id="contacts" alignment="TOP_RIGHT" columnHalignment="RIGHT" orientation="VERTICAL" rowValignment="TOP" HBox.hgrow="ALWAYS">
+               <padding>
+                  <Insets right="15.0" top="15.0" />
+               </padding>
                  </FlowPane>
-            <VBox.margin>
-               <Insets />
-            </VBox.margin>
-            </HBox>
-            <HBox alignment="CENTER_LEFT" prefHeight="18.0" translateX="25.0">
-                <Label styleClass="due_date_label">
-                    <graphic>
-                        <ImageView fitHeight="8.0" pickOnBounds="true" preserveRatio="true">
-                            <image>
-                                <Image url="@/images/deadline_icon_2.png" />
-                            </image>
-                        </ImageView>
-                    </graphic>
-                    <padding>
-                        <Insets bottom="1.0" left="28.0" right="4.0" />
-                    </padding>
-                </Label>
-                  <Label fx:id="deadline" alignment="TOP_RIGHT" contentDisplay="RIGHT" styleClass="due_date_label" textAlignment="RIGHT">
-                      <padding>
-                          <Insets right="10.0" />
-                      </padding>
-                  </Label>
-                <Label styleClass="cell_small_label">
-                    <graphic>
-                        <ImageView fitHeight="10.0" pickOnBounds="true" preserveRatio="true">
-                            <image>
-                                <Image url="@/images/description_icon_2.png" />
-                            </image>
-                        </ImageView>
-                    </graphic>
-                    <padding>
-                        <Insets right="4.0" />
-                    </padding>
-                </Label>
-                <Label fx:id="description" styleClass="cell_small_label" text="\$description" wrapText="true" />
-            <VBox.margin>
-               <Insets bottom="5.0" />
-            </VBox.margin>
-            </HBox>
-            <GridPane.margin>
-                <Insets />
-            </GridPane.margin>
-        </VBox>
+         </children>
+      </HBox>
         <rowConstraints>
             <RowConstraints />
         </rowConstraints>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane prefWidth="750.0" HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" minWidth="750.0" prefHeight="95.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane prefWidth="750.0" HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
@@ -23,7 +23,7 @@
                 <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
             <HBox alignment="CENTER_LEFT" prefHeight="18.0" spacing="5">
-            <StackPane prefHeight="150.0" prefWidth="25.0" styleClass="check_icon">
+            <StackPane minWidth="-Infinity" prefHeight="150.0" prefWidth="25.0" styleClass="check_icon">
                <children>
                   <Label fx:id="checkBox" prefWidth="0.0" styleClass="check_icon">
                       <graphic>
@@ -51,9 +51,9 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="taskName" minWidth="300.0" prefHeight="24.0" prefWidth="299.0" styleClass="cell_big_label" text="\$first">
+                <Label fx:id="taskName" styleClass="cell_big_label" text="\$first" wrapText="true">
                     <padding>
-                        <Insets bottom="2.0" right="10.0" top="5.0" />
+                        <Insets bottom="2.0" right="10.0" top="2.0" />
                     </padding>
                 </Label>
                  <FlowPane fx:id="contacts" alignment="CENTER_RIGHT" columnHalignment="RIGHT" prefHeight="18.0" HBox.hgrow="ALWAYS">
@@ -75,7 +75,7 @@
                         </ImageView>
                     </graphic>
                     <padding>
-                        <Insets bottom="1.0" right="4.0" left="28.0" />
+                        <Insets bottom="1.0" left="28.0" right="4.0" />
                     </padding>
                 </Label>
                   <Label fx:id="deadline" alignment="TOP_RIGHT" contentDisplay="RIGHT" styleClass="due_date_label" textAlignment="RIGHT">
@@ -95,7 +95,7 @@
                         <Insets right="4.0" />
                     </padding>
                 </Label>
-                <Label fx:id="description" styleClass="cell_small_label" text="\$description" />
+                <Label fx:id="description" styleClass="cell_small_label" text="\$description" wrapText="true" />
             <VBox.margin>
                <Insets bottom="5.0" />
             </VBox.margin>


### PR DESCRIPTION
# Issues
- Resolves #178 

# Description
- Task name will not truncate but wrap text to always display the full task name
<img width="962" alt="image" src="https://user-images.githubusercontent.com/105309798/200241496-a5cf4ee3-3c8c-407a-a39b-61b7c0c38790.png">
